### PR TITLE
Add tests: test_pidslm.py

### DIFF
--- a/tests/test_pidslm.py
+++ b/tests/test_pidslm.py
@@ -1,0 +1,350 @@
+"""Tests for piDSLM - Raspberry Pi DSLR Camera Controller"""
+
+import pytest
+import os
+import sys
+import glob
+from unittest.mock import patch, MagicMock
+
+
+def test_app_initialization(source_module):
+    """Test that the piDSLM app initializes correctly"""
+    with patch('guizero.App') as mock_app:
+        with patch('guizero.Window') as mock_window:
+            # Mock the app display method
+            mock_app.return_value.display = MagicMock()
+            mock_app.return_value.tk = MagicMock()
+            mock_app.return_value.tk.attributes = MagicMock()
+            
+            # Mock Window
+            mock_window.return_value.hide = MagicMock()
+            mock_window.return_value.show = MagicMock()
+            
+            # Initialize the app
+            app = source_module.piDSLM()
+            
+            # Verify app was created
+            assert app.app is not None
+            assert app.busy is not None
+            assert app.capture_number is not None
+            assert app.video_capture_number is not None
+
+
+def test_timestamp_generation(source_module):
+    """Test that timestamp generation works correctly"""
+    with patch('guizero.App') as mock_app:
+        with patch('guizero.Window') as mock_window:
+            mock_app.return_value.display = MagicMock()
+            mock_app.return_value.tk = MagicMock()
+            mock_app.return_value.tk.attributes = MagicMock()
+            mock_window.return_value.hide = MagicMock()
+            mock_window.return_value.show = MagicMock()
+            
+            app = source_module.piDSLM()
+            timestamp = app.timestamp()
+            
+            # Verify timestamp format (YYYYMMDD_HHMMSS) - 15 characters
+            assert len(timestamp) == 15
+            assert timestamp[8] == '_'  # Separator
+            # Verify it's a valid date/time format
+            assert timestamp[:8].isdigit()  # Date part
+            assert timestamp[9:].isdigit()  # Time part
+
+
+def test_clear_folder(source_module):
+    """Test the clear folder functionality"""
+    with patch('guizero.App') as mock_app:
+        with patch('guizero.Window') as mock_window:
+            mock_app.return_value.display = MagicMock()
+            mock_app.return_value.tk = MagicMock()
+            mock_app.return_value.tk.attributes = MagicMock()
+            mock_window.return_value.hide = MagicMock()
+            mock_window.return_value.show = MagicMock()
+            
+            app = source_module.piDSLM()
+            
+            # Mock os.system to capture the command
+            with patch('os.system') as mock_system:
+                app.clear()
+                # Verify the rm command was called
+                mock_system.assert_called_once()
+                assert 'rm -v /home/pi/Downloads/*' in mock_system.call_args[0][0]
+
+
+def test_show_hide_busy(source_module):
+    """Test show and hide busy window functionality"""
+    with patch('guizero.App') as mock_app:
+        with patch('guizero.Window') as mock_window:
+            mock_app.return_value.display = MagicMock()
+            mock_app.return_value.tk = MagicMock()
+            mock_app.return_value.tk.attributes = MagicMock()
+            
+            # Track show/hide calls
+            busy_shown = []
+            busy_hidden = []
+            
+            def track_show():
+                busy_shown.append(True)
+            def track_hide():
+                busy_hidden.append(True)
+            
+            mock_window.return_value.hide = track_hide
+            mock_window.return_value.show = track_show
+            
+            app = source_module.piDSLM()
+            
+            # Test show_busy
+            app.show_busy()
+            assert len(busy_shown) == 1
+            
+            # Test hide_busy
+            app.hide_busy()
+            assert len(busy_hidden) == 1
+
+
+def test_video_capture(source_module):
+    """Test video capture functionality"""
+    with patch('guizero.App') as mock_app:
+        with patch('guizero.Window') as mock_window:
+            mock_app.return_value.display = MagicMock()
+            mock_app.return_value.tk = MagicMock()
+            mock_app.return_value.tk.attributes = MagicMock()
+            mock_window.return_value.hide = MagicMock()
+            mock_window.return_value.show = MagicMock()
+            
+            app = source_module.piDSLM()
+            
+            with patch('os.system') as mock_system:
+                app.video_capture()
+                # Verify raspivid command was called
+                mock_system.assert_called_once()
+                assert 'raspivid' in mock_system.call_args[0][0]
+                assert '-t 30000' in mock_system.call_args[0][0]  # 30 seconds
+
+
+def test_burst_capture(source_module):
+    """Test burst capture functionality"""
+    with patch('guizero.App') as mock_app:
+        with patch('guizero.Window') as mock_window:
+            mock_app.return_value.display = MagicMock()
+            mock_app.return_value.tk = MagicMock()
+            mock_app.return_value.tk.attributes = MagicMock()
+            mock_window.return_value.hide = MagicMock()
+            mock_window.return_value.show = MagicMock()
+            
+            app = source_module.piDSLM()
+            
+            with patch('os.system') as mock_system:
+                app.burst()
+                # Verify raspistill command was called for burst
+                mock_system.assert_called_once()
+                assert 'raspistill' in mock_system.call_args[0][0]
+                assert '-tl 0' in mock_system.call_args[0][0]  # Timelapse 0ms
+                assert '-bm' in mock_system.call_args[0][0]  # Burst mode
+
+
+def test_lapse_capture(source_module):
+    """Test timelapse capture functionality"""
+    with patch('guizero.App') as mock_app:
+        with patch('guizero.Window') as mock_window:
+            mock_app.return_value.display = MagicMock()
+            mock_app.return_value.tk = MagicMock()
+            mock_app.return_value.tk.attributes = MagicMock()
+            mock_window.return_value.hide = MagicMock()
+            mock_window.return_value.show = MagicMock()
+            
+            app = source_module.piDSLM()
+            
+            with patch('os.system') as mock_system:
+                app.lapse()
+                # Verify raspistill command was called for timelapse
+                mock_system.assert_called_once()
+                assert 'raspistill' in mock_system.call_args[0][0]
+                assert '-t 3600000' in mock_system.call_args[0][0]  # 1 hour
+                assert '-tl 60000' in mock_system.call_args[0][0]  # 60 second intervals
+
+
+def test_split_hd_30m(source_module):
+    """Test split HD 30 minute capture functionality"""
+    with patch('guizero.App') as mock_app:
+        with patch('guizero.Window') as mock_window:
+            mock_app.return_value.display = MagicMock()
+            mock_app.return_value.tk = MagicMock()
+            mock_app.return_value.tk.attributes = MagicMock()
+            mock_window.return_value.hide = MagicMock()
+            mock_window.return_value.show = MagicMock()
+            
+            app = source_module.piDSLM()
+            
+            with patch('os.system') as mock_system:
+                app.split_hd_30m()
+                # Verify raspivid command was called
+                mock_system.assert_called_once()
+                assert 'raspivid' in mock_system.call_args[0][0]
+                assert '-t 1800000' in mock_system.call_args[0][0]  # 30 minutes
+                assert '-sg 300000' in mock_system.call_args[0][0]  # Split every 5 minutes
+
+
+def test_long_preview(source_module):
+    """Test long preview functionality"""
+    with patch('guizero.App') as mock_app:
+        with patch('guizero.Window') as mock_window:
+            mock_app.return_value.display = MagicMock()
+            mock_app.return_value.tk = MagicMock()
+            mock_app.return_value.tk.attributes = MagicMock()
+            mock_window.return_value.hide = MagicMock()
+            mock_window.return_value.show = MagicMock()
+            
+            app = source_module.piDSLM()
+            
+            with patch('os.system') as mock_system:
+                app.long_preview()
+                # Verify raspistill command was called with 10 second preview
+                mock_system.assert_called_once()
+                assert 'raspistill' in mock_system.call_args[0][0]
+                assert '-t 10000' in mock_system.call_args[0][0]  # 10 seconds
+
+
+def test_capture_image(source_module):
+    """Test single image capture functionality"""
+    with patch('guizero.App') as mock_app:
+        with patch('guizero.Window') as mock_window:
+            mock_app.return_value.display = MagicMock()
+            mock_app.return_value.tk = MagicMock()
+            mock_app.return_value.tk.attributes = MagicMock()
+            mock_window.return_value.hide = MagicMock()
+            mock_window.return_value.show = MagicMock()
+            
+            app = source_module.piDSLM()
+            
+            with patch('os.system') as mock_system:
+                app.capture_image()
+                # Verify raspistill command was called
+                mock_system.assert_called_once()
+                assert 'raspistill' in mock_system.call_args[0][0]
+                assert '-f' in mock_system.call_args[0][0]  # Full preview
+
+
+def test_upload_function(source_module):
+    """Test Dropbox upload functionality"""
+    with patch('guizero.App') as mock_app:
+        with patch('guizero.Window') as mock_window:
+            mock_app.return_value.display = MagicMock()
+            mock_app.return_value.tk = MagicMock()
+            mock_app.return_value.tk.attributes = MagicMock()
+            mock_window.return_value.hide = MagicMock()
+            mock_window.return_value.show = MagicMock()
+            
+            app = source_module.piDSLM()
+            
+            with patch('subprocess.Popen') as mock_popen:
+                app.upload()
+                # Verify subprocess was called with correct arguments
+                mock_popen.assert_called_once()
+                args = mock_popen.call_args[0][0]
+                assert 'python3' in args
+                assert 'dropbox_upload.py' in args
+                assert '--yes' in args
+
+
+def test_fullscreen_functions(source_module):
+    """Test fullscreen toggle functions"""
+    with patch('guizero.App') as mock_app:
+        with patch('guizero.Window') as mock_window:
+            mock_app.return_value.display = MagicMock()
+            mock_app.return_value.tk = MagicMock()
+            mock_app.return_value.tk.attributes = MagicMock()
+            mock_window.return_value.hide = MagicMock()
+            mock_window.return_value.show = MagicMock()
+            
+            app = source_module.piDSLM()
+            
+            # Test fullscreen
+            app.fullscreen()
+            assert mock_app.return_value.tk.attributes.called
+            
+            # Test notfullscreen
+            app.notfullscreen()
+            assert mock_app.return_value.tk.attributes.call_count >= 2
+
+
+def test_gpio_setup(source_module):
+    """Test GPIO pin setup during initialization"""
+    with patch('guizero.App') as mock_app:
+        with patch('guizero.Window') as mock_window:
+            mock_app.return_value.display = MagicMock()
+            mock_app.return_value.tk = MagicMock()
+            mock_app.return_value.tk.attributes = MagicMock()
+            mock_window.return_value.hide = MagicMock()
+            mock_window.return_value.show = MagicMock()
+            
+            with patch('RPi.GPIO') as mock_gpio:
+                app = source_module.piDSLM()
+                
+                # Verify GPIO warnings were disabled first
+                mock_gpio.setwarnings.assert_called_once_with(False)
+                
+                # Verify GPIO mode was set
+                mock_gpio.setmode.assert_called_once()
+                assert mock_gpio.BCM in mock_gpio.setmode.call_args[0]
+                
+                # Verify GPIO 16 was set up as input with pull-up
+                mock_gpio.setup.assert_any_call(16, mock_gpio.IN, pull_up_down=mock_gpio.PUD_UP)
+                
+                # Verify event detection was added
+                mock_gpio.add_event_detect.assert_called_once()
+                assert mock_gpio.add_event_detect.call_args[0][0] == 16
+                assert mock_gpio.add_event_detect.call_args[0][1] == mock_gpio.FALLING
+
+
+def test_picture_index_functions(source_module):
+    """Test picture navigation functions"""
+    with patch('guizero.App') as mock_app:
+        with patch('guizero.Window') as mock_window:
+            mock_app.return_value.display = MagicMock()
+            mock_app.return_value.tk = MagicMock()
+            mock_app.return_value.tk.attributes = MagicMock()
+            mock_window.return_value.hide = MagicMock()
+            mock_window.return_value.show = MagicMock()
+            
+            app = source_module.piDSLM()
+            
+            # Test picture_left with empty list (edge case)
+            app.picture_index = 0
+            app.saved_pictures = []
+            # This will cause IndexError since there are no pictures
+            # but we test the logic before the error
+            with pytest.raises(IndexError):
+                app.picture_left()
+            
+            # Test picture_right with empty list
+            app.picture_index = 0
+            app.saved_pictures = []
+            with pytest.raises(IndexError):
+                app.picture_right()
+
+
+def test_show_gallery(source_module):
+    """Test gallery window functionality"""
+    with patch('guizero.App') as mock_app:
+        with patch('guizero.Window') as mock_window:
+            mock_app.return_value.display = MagicMock()
+            mock_app.return_value.tk = MagicMock()
+            mock_app.return_value.tk.attributes = MagicMock()
+            mock_window.return_value.hide = MagicMock()
+            mock_window.return_value.show = MagicMock()
+            
+            app = source_module.piDSLM()
+            
+            # Mock glob to return some test images
+            with patch('glob.glob') as mock_glob:
+                mock_glob.return_value = ['/home/pi/Downloads/test1.jpg', '/home/pi/Downloads/test2.jpg']
+                
+                with patch('guizero.PushButton') as mock_button:
+                    with patch('guizero.Picture') as mock_picture:
+                        app.show_gallery()
+                        
+                        # Verify gallery window was created
+                        assert app.gallery is not None
+                        mock_glob.assert_called_once()
+                        assert '/home/pi/Downloads/*.jpg' in mock_glob.call_args[0][0]


### PR DESCRIPTION
## Summary
Add tests: test_pidslm.py

## Files Changed
- `/workspace/repo/tests/test_pidslm.py`

## Diff Stats
```
tests/conftest.py    |   2 +-
 tests/test_pidslm.py | 350 +++++++++++++++++++++++++++++++++++++++++++++++++++
 2 files changed, 351 insertions(+), 1 deletion(-)
```

## Test Results

| Metric | Value |
|--------|-------|
| Passed | 10 |
| Failed | 5 |
| Total | 15 |
| Pass Rate | 67% |

<details>
<summary>Full test output</summary>

```
alled_once_with(False)

tests/test_pidslm.py:285: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <MagicMock name='GPIO.setwarnings' id='281473133187472'>, args = (False,)
kwargs = {}, msg = "Expected 'setwarnings' to be called once. Called 0 times."

    def assert_called_once_with(self, /, *args, **kwargs):
        """assert that the mock was called exactly once and that that call was
        with the specified arguments."""
        if not self.call_count == 1:
            msg = ("Expected '%s' to be called once. Called %s times.%s"
                   % (self._mock_name or 'mock',
                      self.call_count,
                      self._calls_repr()))
>           raise AssertionError(msg)
E           AssertionError: Expected 'setwarnings' to be called once. Called 0 times.

/usr/local/lib/python3.12/unittest/mock.py:960: AssertionError
---------------------------- Captured stdout setup -----------------------------
[conftest] Warning loading dropbox_upload.py: missing loader
=============================== warnings summary ===============================
tests/test_pidslm.py: 46 warnings
  /workspace/repo/tests/conftest.py:95: DeprecationWarning: ast.NameConstant is deprecated and will be removed in Python 3.14; use ast.Constant instead
    if isinstance(test, ast.NameConstant) and test.value is True:

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=========================== short test summary info ============================
FAILED tests/test_pidslm.py::test_show_hide_busy - assert 0 == 1
FAILED tests/test_pidslm.py::test_long_preview - AssertionError: assert '-t 1...
FAILED tests/test_pidslm.py::test_upload_function - AssertionError: assert 'd...
FAILED tests/test_pidslm.py::test_fullscreen_functions - AssertionError: asse...
FAILED tests/test_pidslm.py::test_gpio_setup - AssertionError: Expected 'setw...
================== 5 failed, 10 passed, 46 warnings in 0.23s ===================
```
</details>

## Phase
`test` — part of Marisol's autonomous coding pipeline

---
*Generated by Marisol's autonomous coding engine*
