### PR TITLE
Add MARISOL documentation and repo cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,9 @@ debug_*.py
 dist/
 build/
 *.egg-info/
+
+# Auto-added by Marisol pipeline
+.pio/
+.gradle/
+*.class
+local.properties


### PR DESCRIPTION
## Summary
[API Error: 400 "auto" tool choice requires --enable-auto-tool-choice and --tool-call-parser to be set]

## Diff Stats
```
.gitignore            |  6 ++++++
 MARISOL.md            | 12 ++++++++++++
 repo_cache            |  1 +
 tests/test_example.py |  0
 4 files changed, 19 insertions(+)
```

## Phase
`implement` — part of Marisol's autonomous coding pipeline

---
*Generated by Marisol's autonomous coding engine*
